### PR TITLE
feat: キャラクターのTier表を実装

### DIFF
--- a/tiers/src/apis/anilist.ts
+++ b/tiers/src/apis/anilist.ts
@@ -38,6 +38,7 @@ type AnimeInfoQueryResponse = {
 };
 
 export type AnimeInfo = {
+	id: number;
 	title: string;
 	coverImage: string;
 	externalLinks: {
@@ -60,6 +61,7 @@ export const getAnimeInfo = async (id: number): Promise<AnimeInfo> => {
 	});
 	const json = (await response.json()) as AnimeInfoQueryResponse;
 	return {
+		id,
 		title: json.data.Media.title.native,
 		coverImage: json.data.Media.coverImage.large,
 		externalLinks: json.data.Media.externalLinks

--- a/tiers/src/apis/anilist.ts
+++ b/tiers/src/apis/anilist.ts
@@ -136,6 +136,6 @@ export const getCharacterInfo = async (id: number): Promise<CharactersInfo> => {
 		characters: json.data.Media.characters.nodes.map((node) => ({
 			id: node.id,
 			image: node.image.medium,
-		}))
+		})),
 	};
 };

--- a/tiers/src/apis/anilist.ts
+++ b/tiers/src/apis/anilist.ts
@@ -73,3 +73,69 @@ export const getAnimeInfo = async (id: number): Promise<AnimeInfo> => {
 			})),
 	};
 };
+
+const characterInfoQuery = `
+query ($id: Int){
+	Media(id: $id) {
+	title {
+		native
+	}
+	characters {
+			nodes {
+				id
+				image {
+					medium
+				}
+			}
+		}
+	}
+}`;
+
+type CharacterInfoQueryResponse = {
+	data: {
+		Media: {
+			title: {
+				native: string;
+			};
+			characters: {
+				nodes: {
+					id: number;
+					image: {
+						medium: string;
+					};
+				}[];
+			};
+		};
+	};
+};
+
+export type CharactersInfo = {
+	id: number;
+	title: string;
+	characters: {
+		id: number;
+		image: string;
+	}[];
+};
+
+export const getCharacterInfo = async (id: number): Promise<CharactersInfo> => {
+	const response = await fetch(anilistApiUrl, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			query: characterInfoQuery,
+			variables: { id },
+		}),
+	});
+	const json = (await response.json()) as CharacterInfoQueryResponse;
+	return {
+		id,
+		title: json.data.Media.title.native,
+		characters: json.data.Media.characters.nodes.map((node) => ({
+			id: node.id,
+			image: node.image.medium,
+		}))
+	};
+};

--- a/tiers/src/dialogs/AnimeInfo/AnimeInfoDialog.tsx
+++ b/tiers/src/dialogs/AnimeInfo/AnimeInfoDialog.tsx
@@ -11,14 +11,19 @@ import { css } from "../../../styled-system/css";
 import {
 	List,
 	ListItem,
+	ListItemButton,
 	ListItemButtonLink,
 	ListItemText,
 } from "../../components/presentational/List";
+import { useNavigate } from "rocon/react";
+import { charactersRoutes } from "../../pages/Routes";
 
 type AnilistInfoProps = {};
 
 const AnilistInfo: FC<AnilistInfoProps> = memo(() => {
 	const info = useAnimeInfo();
+	const navigate = useNavigate();
+
 	return (
 		<div>
 			<Typography variant="h4">{info.title}</Typography>
@@ -35,6 +40,19 @@ const AnilistInfo: FC<AnilistInfoProps> = memo(() => {
 								</ListItemButtonLink>
 							</ListItem>
 						))}
+						<ListItem>
+							<ListItemButton
+								onClick={() =>
+									navigate(charactersRoutes.anyRoute, {
+										id: info.id.toString(),
+									})
+								}
+							>
+								<ListItemText className={css({ textDecoration: "underline" })}>
+									Characters
+								</ListItemText>
+							</ListItemButton>
+						</ListItem>
 					</List>
 				</div>
 			</div>

--- a/tiers/src/pages/Routes.tsx
+++ b/tiers/src/pages/Routes.tsx
@@ -5,10 +5,15 @@ import { ErrorFallback } from "../components/presentational/ErrorFallback";
 import { TierListPage } from "./TierEditor/TierListPage";
 import { TierViewPage } from "./TierEditor/TierViewPage";
 
+export const charactersRoutes = Rocon.Path().any("id", {
+	action: ({ id }) => <>{id}</>,
+});
+
 export const routes = Rocon.Root({ root: { pathname: "/tiers", state: null } })
 	.attach(Rocon.Path())
 	.exact({ action: () => <TierListPage /> })
-	.any("id", { action: ({ id }) => <TierViewPage defKey={id} /> });
+	.any("id", { action: ({ id }) => <TierViewPage defKey={id} /> })
+	.route("c", (route) => route.attach(charactersRoutes));
 
 export const Routes: FC = () => {
 	return (

--- a/tiers/src/pages/Routes.tsx
+++ b/tiers/src/pages/Routes.tsx
@@ -4,9 +4,10 @@ import { ErrorBoundary } from "../components/functional/ErrorBoundary";
 import { ErrorFallback } from "../components/presentational/ErrorFallback";
 import { TierListPage } from "./TierEditor/TierListPage";
 import { TierViewPage } from "./TierEditor/TierViewPage";
+import { Characters } from "./TierEditor/Characters";
 
 export const charactersRoutes = Rocon.Path().any("id", {
-	action: ({ id }) => <>{id}</>,
+	action: ({ id }) => <Characters id={id} />,
 });
 
 export const routes = Rocon.Root({ root: { pathname: "/tiers", state: null } })

--- a/tiers/src/pages/TierEditor/Card.tsx
+++ b/tiers/src/pages/TierEditor/Card.tsx
@@ -1,4 +1,4 @@
-import { FC, forwardRef, memo } from "react";
+import { FC, forwardRef, memo, useMemo } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useCardSize } from "../../hooks/uiSettings";
@@ -10,10 +10,11 @@ export type DraggableCardProps = {
 	id: string;
 	image: string;
 	onClick?: (() => void) | undefined;
+	variant: "anime" | "character";
 };
 
 export const DraggableCard: FC<DraggableCardProps> = memo(
-	({ image, id, onClick }) => {
+	({ image, id, onClick, variant }) => {
 		const { attributes, listeners, setNodeRef, transform, isDragging } =
 			useSortable({
 				id,
@@ -30,6 +31,7 @@ export const DraggableCard: FC<DraggableCardProps> = memo(
 				listeners={listeners}
 				image={image}
 				onClick={onClick}
+				variant={variant}
 			/>
 		);
 	},
@@ -43,6 +45,7 @@ export type CardProps = {
 	style?: React.CSSProperties | undefined;
 	overlay?: boolean;
 	onClick?: (() => void) | undefined;
+	variant: "anime" | "character";
 };
 
 const cardStyle = cva({
@@ -63,8 +66,20 @@ const cardStyle = cva({
 });
 
 export const Card = forwardRef<HTMLDivElement, CardProps>(
-	({ image, attributes, listeners, style, overlay, onClick }, ref) => {
+	({ image, attributes, listeners, style, overlay, onClick, variant }, ref) => {
 		const cardSize = useCardSize();
+		const sizeStyle = useMemo<{ width: string; height: string }>(() => {
+			if (variant === "character") {
+				return {
+					width: `${cardSize}px`,
+					height: `${cardSize * 1.5}px`,
+				};
+			}
+			return {
+				width: `${cardSize}px`,
+				height: `${cardSize}px`,
+			};
+		}, [cardSize, variant]);
 		return (
 			<div
 				ref={ref}
@@ -74,14 +89,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
 				{...listeners}
 				className={cardStyle({ overlay: !!overlay })}
 			>
-				<img
-					src={image}
-					alt=""
-					style={{
-						width: `${cardSize}px`,
-						height: `${cardSize}px`,
-					}}
-				/>
+				<img src={image} alt="" style={sizeStyle} />
 			</div>
 		);
 	},

--- a/tiers/src/pages/TierEditor/Characters.tsx
+++ b/tiers/src/pages/TierEditor/Characters.tsx
@@ -1,0 +1,39 @@
+import { FC } from "react";
+import { Page } from "../../components/presentational/Page";
+import { Appbar } from "../../components/presentational/Appbar";
+import { Link } from "../../components/presentational/Link";
+import { useNavigate } from "rocon/react";
+import { routes } from "../Routes";
+import { BreadcrumbsSeparator } from "../../components/presentational/BreadcrumbsSeparator";
+import { Typography } from "../../components/presentational/Typography";
+import { MainLayout } from "../../components/presentational/MainLayout";
+
+const Title: FC = () => {
+	const navigate = useNavigate();
+
+	return (
+		<Appbar>
+			<Link
+				underline="hover"
+				color="inherit"
+				onClick={() => navigate(routes.exactRoute)}
+			>
+				Tiers
+			</Link>
+			<BreadcrumbsSeparator />
+			<Typography>Characters</Typography>
+		</Appbar>
+	);
+};
+
+const Main: FC<{ id: string }> = ({ id }) => {
+	return <div>Characters</div>;
+};
+
+export const Characters: FC<{ id: string }> = ({ id }) => {
+	return (
+		<Page>
+			<MainLayout title={<Title />} main={<Main id={id} />} />
+		</Page>
+	);
+};

--- a/tiers/src/pages/TierEditor/Characters.tsx
+++ b/tiers/src/pages/TierEditor/Characters.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, Suspense } from "react";
 import { Page } from "../../components/presentational/Page";
 import { Appbar } from "../../components/presentational/Appbar";
 import { Link } from "../../components/presentational/Link";
@@ -7,6 +7,10 @@ import { routes } from "../Routes";
 import { BreadcrumbsSeparator } from "../../components/presentational/BreadcrumbsSeparator";
 import { Typography } from "../../components/presentational/Typography";
 import { MainLayout } from "../../components/presentational/MainLayout";
+import { CharactersTier } from "./CharactersTier";
+import { ErrorBoundary } from "../../components/functional/ErrorBoundary";
+import { ErrorFallback } from "../../components/presentational/ErrorFallback";
+import { css } from "../../../styled-system/css";
 
 const Title: FC = () => {
 	const navigate = useNavigate();
@@ -26,9 +30,27 @@ const Title: FC = () => {
 	);
 };
 
-const Main: FC<{ id: string }> = ({ id }) => {
-	return <div>Characters</div>;
-};
+const Main: FC<{ id: string }> = ({ id }) => (
+	<ErrorBoundary
+		fallback={(error, errorInfo) => (
+			<ErrorFallback error={error} errorInfo={errorInfo} />
+		)}
+	>
+		<Suspense fallback={"loading"}>
+			<div
+				className={css({
+					w: "full",
+					h: "full",
+					p: "2",
+					overflowY: "scroll",
+					overflowX: "hidden",
+				})}
+			>
+				<CharactersTier id={id} />
+			</div>
+		</Suspense>
+	</ErrorBoundary>
+);
 
 export const Characters: FC<{ id: string }> = ({ id }) => {
 	return (

--- a/tiers/src/pages/TierEditor/CharactersTier.tsx
+++ b/tiers/src/pages/TierEditor/CharactersTier.tsx
@@ -1,0 +1,124 @@
+import { FC, useMemo, useState } from "react";
+import {
+	TierMapping,
+	swapOrder,
+	useCharacterTierMapping,
+	useCharactersInfo,
+	useSetCharacterTierMapping,
+} from "./store";
+import { DragEndEvent, DragOverEvent, DragStartEvent } from "@dnd-kit/core";
+import { standardTiers } from "../../apis/tiers";
+import produce from "immer";
+import { TierView } from "./TierView";
+
+const findRow = (mapping: TierMapping, id: string | null) => {
+	if (!id) {
+		return null;
+	}
+	const row = standardTiers.find((v) => v.key === id);
+	if (row) {
+		return row.key;
+	}
+	for (const [key, value] of Object.entries(mapping.mappings)) {
+		if (value.ids.find((s) => s === id)) {
+			return key;
+		}
+	}
+	return null;
+};
+
+export type CharactersTierProps = {
+	id: string;
+};
+
+export const CharactersTier: FC<CharactersTierProps> = ({ id }) => {
+	const idn = parseInt(id);
+	const charactersData = useCharactersInfo(idn);
+	const images = useMemo<Record<string, string>>(() => {
+		const images: Record<string, string> = {};
+		for (const character of charactersData.characters) {
+			images[character.id] = character.image;
+		}
+		return images;
+	}, [charactersData]);
+	const tierMapping = useCharacterTierMapping({ id: idn, images });
+	const setTierMapping = useSetCharacterTierMapping({ id: idn, images });
+	const [currentId, setCurrentId] = useState<string | null>(null);
+
+	const handleDragStart = (event: DragStartEvent) => {
+		setCurrentId(String(event.active.id));
+	};
+
+	const handleDragOver = (event: DragOverEvent) => {
+		const { active, over } = event;
+		const activeId = String(active.id);
+		const overId = over ? String(over.id) : null;
+		const activeColumnKey = findRow(tierMapping, activeId);
+		const overColumnKey = findRow(tierMapping, overId);
+		if (
+			activeColumnKey == null ||
+			overColumnKey == null ||
+			activeColumnKey === overColumnKey
+		) {
+			return null;
+		}
+		setTierMapping(
+			produce((draft) => {
+				Object.entries(draft.mappings).forEach(([key, value]) => {
+					if (key === activeColumnKey) {
+						value.ids = value.ids.filter((id) => id !== activeId);
+					}
+					if (key === overColumnKey) {
+						value.ids.push(activeId);
+					}
+				});
+			}),
+		);
+		return;
+	};
+
+	const handleDragEnd = (event: DragEndEvent) => {
+		const { active, over } = event;
+		const activeId = String(active.id);
+		const overId = over ? String(over.id) : null;
+		const activeColumnKey = findRow(tierMapping, activeId);
+		const overColumnKey = findRow(tierMapping, overId);
+		if (
+			activeColumnKey == null ||
+			overColumnKey == null ||
+			activeColumnKey !== overColumnKey
+		) {
+			return null;
+		}
+		setTierMapping(
+			produce((draft) => {
+				Object.entries(draft.mappings).forEach(([key, value]) => {
+					if (key === activeColumnKey) {
+						const activeIndex = value.ids.findIndex((i) => i === activeId);
+						const overIndex = value.ids.findIndex((i) => i === overId);
+						if (
+							0 <= activeIndex &&
+							0 <= overIndex &&
+							activeIndex !== overIndex
+						) {
+							value.ids = swapOrder(value.ids, activeIndex, overIndex);
+						}
+					}
+				});
+			}),
+		);
+		return;
+	};
+
+	return (
+		<TierView
+			title={charactersData.title}
+			handleDragStart={handleDragStart}
+			handleDragOver={handleDragOver}
+			handleDragEnd={handleDragEnd}
+			images={images}
+			currentId={currentId}
+			mappings={tierMapping.mappings}
+		/>
+	);
+};

--- a/tiers/src/pages/TierEditor/CharactersTier.tsx
+++ b/tiers/src/pages/TierEditor/CharactersTier.tsx
@@ -112,6 +112,7 @@ export const CharactersTier: FC<CharactersTierProps> = ({ id }) => {
 
 	return (
 		<TierView
+			variant="character"
 			title={charactersData.title}
 			handleDragStart={handleDragStart}
 			handleDragOver={handleDragOver}

--- a/tiers/src/pages/TierEditor/Row.tsx
+++ b/tiers/src/pages/TierEditor/Row.tsx
@@ -63,6 +63,7 @@ export const TierRow: FC<TierRowProps> = memo(({ tier, images, ids }) => {
 							id={id}
 							image={images[id] ?? ""}
 							onClick={() => openInfoDialog(id)}
+							variant="anime"
 						/>
 					))}
 				</ImageContainer>
@@ -72,3 +73,35 @@ export const TierRow: FC<TierRowProps> = memo(({ tier, images, ids }) => {
 	);
 });
 TierRow.displayName = "TierRow";
+
+export const CharacterTierRow: FC<TierRowProps> = memo(
+	({ tier, images, ids }) => {
+		const { setNodeRef } = useDroppable({ id: tier.label });
+		// const openInfoDialog = useOpenDialog();
+
+		return (
+			<SortableContext id={tier.key} items={ids} strategy={rectSortingStrategy}>
+				<RowGrid>
+					<TierLabel key={tier.key} color={tier.color} label={tier.label} />
+					<div
+						className={css({ pl: "1", opacity: "0.5" })}
+						style={{ backgroundColor: tier.color }}
+					/>
+					<ImageContainer ref={setNodeRef}>
+						{ids.map((id) => (
+							<DraggableCard
+								key={id}
+								id={id}
+								image={images[id] ?? ""}
+								// onClick={() => openInfoDialog(id)}
+								variant="character"
+							/>
+						))}
+					</ImageContainer>
+				</RowGrid>
+				<Divider />
+			</SortableContext>
+		);
+	},
+);
+CharacterTierRow.displayName = "CharacterTierRow";

--- a/tiers/src/pages/TierEditor/TierView.tsx
+++ b/tiers/src/pages/TierEditor/TierView.tsx
@@ -23,7 +23,7 @@ import {
 	useTierData,
 	useTierMapping,
 } from "./store";
-import { standardTiers } from "../../apis/tiers";
+import { TierKey, standardTiers } from "../../apis/tiers";
 import { css } from "../../../styled-system/css";
 
 const findRow = (mapping: TierMapping, id: string | null) => {
@@ -59,11 +59,11 @@ const TiersContainer = forwardRef<
 	</div>
 ));
 
-export type TierViewProps = {
+export type AnimeTierViewProps = {
 	defKey: string;
 };
 
-export const TierView: FC<TierViewProps> = memo((props) => {
+export const AnimeTierView: FC<AnimeTierViewProps> = memo((props) => {
 	const tierData = useTierData(props.defKey);
 	const tierMapping = useTierMapping(props.defKey);
 	const setTierMapping = useSetTierMapping(props.defKey);
@@ -134,6 +134,38 @@ export const TierView: FC<TierViewProps> = memo((props) => {
 		return;
 	};
 
+	return (
+		<TierView
+			title={tierData.definition.title}
+			handleDragStart={handleDragStart}
+			handleDragOver={handleDragOver}
+			handleDragEnd={handleDragEnd}
+			images={tierData.images}
+			currentId={currentId}
+			mappings={tierMapping.mappings}
+		/>
+	);
+});
+
+export type TierViewProps = {
+	title: string;
+	images: Record<string, string>;
+	handleDragStart: (event: DragStartEvent) => void;
+	handleDragOver: (event: DragOverEvent) => void;
+	handleDragEnd: (event: DragEndEvent) => void;
+	currentId?: string | null;
+	mappings: Record<TierKey, { ids: string[] }>;
+};
+
+export const TierView: FC<TierViewProps> = ({
+	title,
+	handleDragStart,
+	handleDragOver,
+	handleDragEnd,
+	images,
+	currentId,
+	mappings,
+}) => {
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: 1 } }),
 	);
@@ -146,7 +178,7 @@ export const TierView: FC<TierViewProps> = memo((props) => {
 					justifyContent: "center",
 				})}
 			>
-				<Typography variant="h4">{tierData.definition.title}</Typography>
+				<Typography variant="h4">{title}</Typography>
 			</div>
 			<DndContext
 				sensors={sensors}
@@ -161,23 +193,23 @@ export const TierView: FC<TierViewProps> = memo((props) => {
 						<TierRow
 							key={tier.key}
 							tier={tier}
-							images={tierData.images}
-							ids={tierMapping.mappings[tier.key]?.ids || []}
+							images={images}
+							ids={mappings[tier.key]?.ids || []}
 						/>
 					))}
 					<TierRow
 						key={uncategorizedTier.key}
 						tier={uncategorizedTier}
-						images={tierData.images}
-						ids={tierMapping.mappings[uncategorizedTier.key]?.ids || []}
+						images={images}
+						ids={mappings[uncategorizedTier.key]?.ids || []}
 					/>
 				</TiersContainer>
 				<DragOverlay>
 					{currentId != null ? (
-						<Card image={tierData.images[currentId] ?? ""} overlay />
+						<Card image={images[currentId] ?? ""} overlay />
 					) : null}
 				</DragOverlay>
 			</DndContext>
 		</>
 	);
-});
+};

--- a/tiers/src/pages/TierEditor/TierView.tsx
+++ b/tiers/src/pages/TierEditor/TierView.tsx
@@ -13,7 +13,7 @@ import {
 } from "@dnd-kit/core";
 import { produce } from "immer";
 
-import { TierRow } from "./Row";
+import { CharacterTierRow, TierRow } from "./Row";
 import { Card } from "./Card";
 import {
 	TierMapping,
@@ -136,6 +136,7 @@ export const AnimeTierView: FC<AnimeTierViewProps> = memo((props) => {
 
 	return (
 		<TierView
+			variant="anime"
 			title={tierData.definition.title}
 			handleDragStart={handleDragStart}
 			handleDragOver={handleDragOver}
@@ -155,6 +156,7 @@ export type TierViewProps = {
 	handleDragEnd: (event: DragEndEvent) => void;
 	currentId?: string | null;
 	mappings: Record<TierKey, { ids: string[] }>;
+	variant: "anime" | "character";
 };
 
 export const TierView: FC<TierViewProps> = ({
@@ -165,10 +167,12 @@ export const TierView: FC<TierViewProps> = ({
 	images,
 	currentId,
 	mappings,
+	variant,
 }) => {
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: 1 } }),
 	);
+	const Row = variant === "anime" ? TierRow : CharacterTierRow;
 	return (
 		<>
 			<div
@@ -190,14 +194,14 @@ export const TierView: FC<TierViewProps> = ({
 			>
 				<TiersContainer>
 					{standardTiers.map((tier) => (
-						<TierRow
+						<Row
 							key={tier.key}
 							tier={tier}
 							images={images}
 							ids={mappings[tier.key]?.ids || []}
 						/>
 					))}
-					<TierRow
+					<Row
 						key={uncategorizedTier.key}
 						tier={uncategorizedTier}
 						images={images}
@@ -206,7 +210,7 @@ export const TierView: FC<TierViewProps> = ({
 				</TiersContainer>
 				<DragOverlay>
 					{currentId != null ? (
-						<Card image={images[currentId] ?? ""} overlay />
+						<Card image={images[currentId] ?? ""} overlay variant={variant} />
 					) : null}
 				</DragOverlay>
 			</DndContext>

--- a/tiers/src/pages/TierEditor/TierViewPage.tsx
+++ b/tiers/src/pages/TierEditor/TierViewPage.tsx
@@ -14,7 +14,7 @@ import { IconButton } from "../../components/presentational/IconButton";
 import { css } from "../../../styled-system/css";
 import { SettingsIcon } from "../../components/presentational/Icons";
 import { Link } from "../../components/presentational/Link";
-import { TierView } from "./TierView";
+import { AnimeTierView } from "./TierView";
 import { AnimeInfoDialog } from "../../dialogs/AnimeInfo/AnimeInfoDialog";
 
 const Title: FC<{ defKey: string }> = ({ defKey }) => {
@@ -65,7 +65,7 @@ const Main: FC<{ defKey: string }> = ({ defKey }) => (
 					overflowX: "hidden",
 				})}
 			>
-				<TierView defKey={defKey} />
+				<AnimeTierView defKey={defKey} />
 			</div>
 		</Suspense>
 	</ErrorBoundary>

--- a/tiers/src/pages/TierEditor/store.ts
+++ b/tiers/src/pages/TierEditor/store.ts
@@ -16,6 +16,7 @@ import {
 	standardTiers,
 } from "../../apis/tiers";
 import type { DeepNullable } from "../../libs/types";
+import { CharactersInfo, getCharacterInfo } from "../../apis/anilist";
 
 const tiersQuery = selector<Tiers>({
 	key: "tiers",
@@ -127,3 +128,14 @@ export const swapOrder = <T>(items: T[], active: number, over: number): T[] => {
 	const filtered = items.filter((_, index) => index !== active);
 	return [...filtered.slice(0, over), item, ...filtered.slice(over)];
 };
+
+export const charactersDataQuery = selectorFamily<CharactersInfo, number>({
+	key: "charactersInfo",
+	get: (key) => async () => {
+		return await getCharacterInfo(key);
+	},
+});
+
+export const useCharactersInfo = (key: number) => {
+	return useRecoilValue(charactersDataQuery(key));
+}

--- a/tiers/src/pages/TierEditor/store.ts
+++ b/tiers/src/pages/TierEditor/store.ts
@@ -138,4 +138,58 @@ export const charactersDataQuery = selectorFamily<CharactersInfo, number>({
 
 export const useCharactersInfo = (key: number) => {
 	return useRecoilValue(charactersDataQuery(key));
-}
+};
+
+const characterTierMappingEffect: (
+	key: CharacterInfoKey,
+) => AtomEffect<TierMapping> = (key) => ({ setSelf, onSet }) => {
+	const itemKey = `c/${key.id}`;
+	const savedValue = localStorage.getItem(itemKey);
+	if (savedValue != null) {
+		setSelf(
+			normalizeMapping(
+				{
+					images: key.images,
+					definition: { query: { season: null, seasonYear: 0 }, title: "" },
+				},
+				JSON.parse(savedValue),
+			),
+		);
+	} else {
+		setSelf(
+			normalizeMapping(
+				{
+					images: key.images,
+					definition: { query: { season: null, seasonYear: 0 }, title: "" },
+				},
+				undefined,
+			),
+		);
+	}
+	onSet((newValue, _, isReset) => {
+		if (isReset) {
+			localStorage.removeItem(itemKey);
+		} else {
+			localStorage.setItem(itemKey, JSON.stringify(newValue));
+		}
+	});
+};
+
+type CharacterInfoKey = {
+	id: number;
+	images: Record<string, string>;
+};
+
+const characterTierMappingStore = atomFamily<TierMapping, CharacterInfoKey>({
+	key: "characterTierMappingState",
+	default: { mappings: {} },
+	effects: (key) => [characterTierMappingEffect(key)],
+});
+
+export const useCharacterTierMapping = (key: CharacterInfoKey) => {
+	return useRecoilValue(characterTierMappingStore(key));
+};
+
+export const useSetCharacterTierMapping = (key: CharacterInfoKey) => {
+	return useSetRecoilState(characterTierMappingStore(key));
+};


### PR DESCRIPTION
## 修正内容
- キャラクターのTier表を新規作成
- アニメの関連リンクの中から飛べるようにした

## 既知の問題
- 既にリストにあるアニメからしか飛べないので2021年以前のアニメが非対応
